### PR TITLE
enh(ci): add check status workflow in centreon/drawio

### DIFF
--- a/.github/workflows/check-status.yml
+++ b/.github/workflows/check-status.yml
@@ -29,7 +29,7 @@ jobs:
 
           ITERATIONS=1
           while [[ $ITERATIONS -le 60 ]]; do
-              CHECK_SUITES=$(gh api -H "Accept: application/vnd.github+json" /repos/centreon/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}/check-suites | jq '. | .check_suites[] | select(.app.slug == "github-actions")' | jq -r '.conclusion // "pending"') || true
+              CHECK_SUITES=$(gh api -H "Accept: application/vnd.github+json" /repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}/check-suites | jq '. | .check_suites[] | select(.app.slug == "github-actions")' | jq -r '.conclusion // "pending"') || true
 
               if [ $(echo $CHECK_SUITES | grep -o -i 'pending' | wc -l) -eq 0 ]; then
                   echo "Cannot get pull request check status"

--- a/.github/workflows/check-status.yml
+++ b/.github/workflows/check-status.yml
@@ -1,0 +1,70 @@
+name: check-status
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - "[2-9][0-9].[0-9][0-9].x"
+
+jobs:
+  check-status:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Check other workflow statuses and display token usage
+        run: |
+          display_token_usage () {
+            echo "current token usage:"
+            curl -s -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/rate_limit | jq .rate
+            echo ""
+          }
+
+          display_token_usage
+          sleep 30s
+
+          ITERATIONS=1
+          while [[ $ITERATIONS -le 60 ]]; do
+              CHECK_SUITES=$(gh api -H "Accept: application/vnd.github+json" /repos/centreon/centreon/commits/${{ github.event.pull_request.head.sha }}/check-suites | jq '. | .check_suites[] | select(.app.slug == "github-actions")' | jq -r '.conclusion // "pending"') || true
+
+              if [ $(echo $CHECK_SUITES | grep -o -i 'pending' | wc -l) -eq 0 ]; then
+                  echo "Cannot get pull request check status"
+                  exit 1
+              fi
+
+              if [ $(echo $CHECK_SUITES | wc -w) -eq 1 ]; then
+                  echo "this job is the only triggered one"
+                  exit 0
+              fi
+
+              if [ $(echo $CHECK_SUITES | grep -o -i 'failure' | wc -l) -gt 0 ]; then
+                  echo "some jobs have failed"
+                  exit 1
+              fi
+
+              # only remaining pending job should be check-status itself
+              if [ $(echo $CHECK_SUITES | grep -o -i 'pending' | wc -l) -eq 1 ]; then
+                  echo "all jobs have passed"
+                  exit 0
+              fi
+
+              if [ $ITERATIONS -lt 60 ]; then
+                  echo "some jobs are still in progress, next try in 60 seconds... (tries: $ITERATIONS/60)"
+                  sleep 30s
+                  display_token_usage
+                  sleep 30s
+                  display_token_usage
+              fi
+
+              ITERATIONS=$((ITERATIONS+1))
+          done
+
+          echo "Timeout: some jobs are still in progress"
+          exit 1
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/check-status.yml
+++ b/.github/workflows/check-status.yml
@@ -29,7 +29,7 @@ jobs:
 
           ITERATIONS=1
           while [[ $ITERATIONS -le 60 ]]; do
-              CHECK_SUITES=$(gh api -H "Accept: application/vnd.github+json" /repos/centreon/centreon/commits/${{ github.event.pull_request.head.sha }}/check-suites | jq '. | .check_suites[] | select(.app.slug == "github-actions")' | jq -r '.conclusion // "pending"') || true
+              CHECK_SUITES=$(gh api -H "Accept: application/vnd.github+json" /repos/centreon/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}/check-suites | jq '. | .check_suites[] | select(.app.slug == "github-actions")' | jq -r '.conclusion // "pending"') || true
 
               if [ $(echo $CHECK_SUITES | grep -o -i 'pending' | wc -l) -eq 0 ]; then
                   echo "Cannot get pull request check status"


### PR DESCRIPTION
## Description

the rules of several repositories (centreon/drawio being one of them) do not prevent someone from merging their PR while the run is still in progress
for that reason, this PR adds a check status workflow (which is the one that exists in other repositories but adapted for centreon/drawio) to check that all steps that all workflow steps are successful before offering the possibility to merge

Fixes # MON-93853

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
