### PR TITLE
fix(drawio): Update package.json after update of crypto-js

### DIFF
--- a/etc/dependencies/package.json
+++ b/etc/dependencies/package.json
@@ -14,7 +14,7 @@
 	  "jquery": "3.6.0",
 	  "mermaid": "10.9.3",
 	  "pako": "2.0.3",
-	  "crypto-js": "3.1.2",
+	  "crypto-js": "4.2.0",
 	  "dompurify": "2.5.8",
 	  "spin.js": "2.0.0",
 	  "roughjs": "4.4.1",


### PR DESCRIPTION
## Description

This was forgotten in https://github.com/centreon/drawio/pull/206

Second part of [MON-161618](https://centreon.atlassian.net/browse/MON-161618)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

[MON-161618]: https://centreon.atlassian.net/browse/MON-161618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ